### PR TITLE
fix(database-legacy): rename docker target to database-server

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -29,7 +29,8 @@ jobs:
     needs: [test]
     strategy:
       matrix:
-        docker-build-target: [blog, admin, game-2048, auth-server, database]
+        docker-build-target:
+          [blog, admin, game-2048, auth-server, database-server]
     uses: ./.github/workflows/docker-image-build-and-push.yml
     secrets: inherit
     with:

--- a/.github/workflows/database-legacy-server-docker-image-build-and-push.yml
+++ b/.github/workflows/database-legacy-server-docker-image-build-and-push.yml
@@ -22,5 +22,5 @@ jobs:
     secrets: inherit
     with:
       docker-file-path: ./Dockerfile
-      docker-build-target: database
+      docker-build-target: database-server
       push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ CMD ["/auth/auth-server"]
 FROM deps AS database-server-builder
 RUN bun --filter "./apps/server/database-legacy" build
 
-FROM alpine:latest AS database
+FROM alpine:latest AS database-server
 COPY --from=database-server-builder /website/apps/server/database-legacy/dist/database-legacy-server /database/database-server
 RUN chmod +x /database/database-server \
     && addgroup -S databasegroup \


### PR DESCRIPTION
## Summary
- Rename the Docker build target from `database` to `database-server` for consistency with other server apps (e.g., `auth-server`)

## Test plan
- [ ] CI workflow builds successfully with the new target name

🤖 Generated with [Claude Code](https://claude.com/claude-code)