### PR TITLE
fix(docker): use oven/bun:debian for glibc compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/go/dockerfile-reference/
 
-FROM oven/bun:alpine AS base
+FROM oven/bun:debian AS base
 
 FROM base AS deps
 WORKDIR /website


### PR DESCRIPTION
## Summary
- Use `oven/bun:debian` as base image instead of `oven/bun:alpine`
- The compiled binaries need to be built with glibc to run on `debian:stable-slim`
- Using `oven/bun:alpine` creates musl-linked binaries that won't run on glibc systems

## Test plan
- [x] Docker images build successfully
- [ ] Server binaries run without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)