### PR TITLE
feat(admin-legacy): migrate admin server from servers repo

### DIFF
--- a/.github/workflows/admin-legacy-server-docker-image-build-and-push.yml
+++ b/.github/workflows/admin-legacy-server-docker-image-build-and-push.yml
@@ -1,0 +1,25 @@
+name: Admin Legacy Server Docker Image Build and Push
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'apps/server/admin-legacy/**'
+      - 'modules/**'
+      - 'libraries/**'
+      - 'bun.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/docker-image-build-and-push.yml
+    secrets: inherit
+    with:
+      docker-file-path: ./apps/server/admin-legacy/Dockerfile
+      docker-build-target: admin-server-legacy
+      push-to-registry: true

--- a/apps/server/admin-legacy/Dockerfile
+++ b/apps/server/admin-legacy/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM oven/bun:alpine AS base
+WORKDIR /website
+COPY . .
+RUN bun install --frozen-lockfile
+
+FROM base AS builder
+RUN bun --filter "./apps/server/admin-legacy" build
+
+FROM oven/bun:alpine AS admin-server-legacy
+COPY --from=builder /website/apps/server/admin-legacy/dist /admin/dist
+RUN addgroup -S admingroup \
+    && adduser -S -G admingroup adminuser \
+    && chown -R adminuser:admingroup /admin
+WORKDIR /admin
+EXPOSE 4003
+USER adminuser
+CMD ["bun", "run", "dist/index.js"]

--- a/apps/server/admin-legacy/README.md
+++ b/apps/server/admin-legacy/README.md
@@ -1,0 +1,22 @@
+# Admin Server
+
+## 简介
+
+本项目是个人网站管理后台的后端。
+
+## 响应对象
+
+```ts
+class Response {
+  public isSuccessful: boolean; // 本次请求是否成功
+  public message?: string; // 请求失败时，显示给用户的消息
+  public data?: any; // 请求成功时，前端需要的数据
+}
+```
+
+- 当因服务器发生错误无法产生响应时，消息填写“服务器错误”
+- 当请求参数错误时，消息填写“请求参数错误”
+
+## 模块文档
+
+- [博客模块](document/blog.md)

--- a/apps/server/admin-legacy/build.ts
+++ b/apps/server/admin-legacy/build.ts
@@ -1,0 +1,4 @@
+import {buildServer, createServerBuildConfig} from '@config/bun/server';
+
+const config = createServerBuildConfig(['./src/index.ts']);
+await buildServer(config);

--- a/apps/server/admin-legacy/document/blog.md
+++ b/apps/server/admin-legacy/document/blog.md
@@ -1,0 +1,287 @@
+# 博客模块
+
+## 主要功能
+
+本模块主要负责博客模块的管理。
+
+### 文章
+
+- 文章添加
+- 文章删除
+- 文章编辑
+
+### 分类
+
+- 分类添加
+- 分类删除
+- 分类修改
+
+---
+
+## 对象
+
+当请求对象中特定值为 `undefined` 时，代表采用数据库现存的值或默认值。
+
+当请求对象中特定值为 `null` 时，代表在数据库中存储 `NULL` 值。
+
+### Article
+
+```ts
+class Article {
+  public id: number; // 自增主键
+  public title: string; // 文章标题，唯一
+  public content: string;
+  public category: number; // 文章分类，外键
+  public publicationTime: string; // 发表日期，ISO 标准日期字符串，默认值为现在
+  public modificationTime: string; // 编辑日期，ISO 标准日期字符串，默认值为现在
+  public pageViews: number; // 浏览量，默认值 0
+  public isVisible: boolean; // 可见性，默认值 true
+}
+```
+
+### Category
+
+```ts
+class Category {
+  public id: number; // 自增主键
+  public name: string; // 分类名，唯一
+}
+```
+
+---
+
+## 接口文档
+
+本模块的接口前缀为 `/blog`。
+
+### 文章（`/article`）
+
+#### `/getById`
+
+- 功能说明：根据 ID 找到对应文章
+- 请求方法：GET
+- 请求对象：
+
+```ts
+{
+    json: {         // JSON 串
+        id: number,
+    },
+}
+```
+
+- 成功响应对象：[Article](#article) 实例
+- 失败响应消息
+  - 未登录：请先登录
+  - 文章不存在：文章不存在
+- 其他说明：无
+
+#### `/getAll`
+
+- 功能说明：得到所有文章
+- 请求方法：GET
+- 请求对象：无
+- 成功响应对象：[Article](#article) 实例数组
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/getByCategory`
+
+- 功能说明：得到所有指定分类下的文章
+- 请求方法：GET
+- 请求对象：
+
+```ts
+{
+    json: {     // JSON 串
+        category: number,
+    },
+}
+```
+
+- 成功响应对象：[Article](#article) 实例数组
+- 失败响应消息：
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/add`
+
+- 功能说明：添加文章
+- 请求方法：POST
+- 请求对象：`Pick<Article, 'title' | 'content' | 'category' | 'isVisible'>` 实例
+- 成功响应对象：无
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明
+  - 数据库层已做参数检查
+
+#### `/deleteById`
+
+- 功能说明：删除文章
+- 请求方法：POST
+- 请求对象：
+
+```ts
+{
+  id: number;
+}
+```
+
+- 成功响应对象：无
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/modify`
+
+- 功能说明：修改文章
+- 请求方法：POST
+- 请求对象：`Pick<Article, 'id'> & Partial<Omit<Article, 'publicationTime' | 'modificationTime' | 'pageViews'>>` 实例
+- 成功响应对象：无
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+### 分类（`/category`）
+
+#### `/getById`
+
+- 功能说明：根据 ID 获取文章分类信息
+- 请求方法：GET
+- 请求对象：
+
+```ts
+{
+    json: { // JSON 串
+        id: number,
+    },
+}
+```
+
+- 成功响应对象：[Category](#category) 实例
+- 失败响应消息
+  - id 不存在：文章分类不存在
+- 其他说明：无
+
+#### `/getAll`
+
+- 功能说明：得到所有文章分类
+- 请求方法：GET
+- 请求对象：无
+- 成功响应对象：[Category](#category) 实例数组
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/getAllArticleAmountById`
+
+- 功能说明：得到所有文章分类有多少个文章
+- 请求方法：GET
+- 请求对象：无
+- 成功响应对象：
+
+```ts
+{
+    [id]: number;   // ID: 文章数量
+}
+```
+
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/getArticleAmountById`
+
+- 功能说明：得到 ID 对应文章分类有多少个文章
+- 请求方法：GET
+- 请求对象：
+
+```ts
+{
+    json: { // JSON 串
+        id: number,
+    },
+}
+```
+
+- 成功响应对象：`number` 实例
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明：无
+
+#### `/add`
+
+- 功能说明：添加文章分类
+- 请求方法：POST
+- 请求对象：`Omit<Category, 'id'>` 实例
+- 成功响应对象：无
+- 失败响应消息
+  - 未登录：请先登录
+- 其他说明
+  - 参数检查在数据库层
+
+#### `/deleteById`
+
+- 功能说明：根据 ID 删除文章分类
+- 请求方法：POST
+- 请求对象：
+
+```ts
+{
+  id: number;
+}
+```
+
+- 成功响应对象：无
+- 失败响应消息：无
+- 其他说明：无
+
+#### `/modify`
+
+- 功能说明：修改文章分类
+- 请求方法：POST
+- 请求对象：`Partial<Category> & Pick<Category, 'id'>` 实例
+- 成功响应对象：无
+- 失败响应消息：无
+- 其他说明
+  - 参数检查在数据库层
+
+### 设置相关（前缀为 `/option`）
+
+#### `/getAbout`
+
+- 功能说明：获得关于内容
+- 请求方法：GET
+- 请求对象：无
+- 成功响应对象
+
+```ts
+{
+    about: string,
+}
+```
+
+- 失败响应消息：无
+- 其他说明
+  - 如果存储文件不存在返回空字符串
+  - 存储在用户文件夹下 `.blog-data` 目录中，文件名为 `about.md`
+
+#### `/setAbout`
+
+- 功能说明：设置关于内容
+- 请求方法：POST
+- 请求对象
+
+```ts
+{
+    about: string,
+}
+```
+
+- 成功响应对象：无
+- 失败响应消息：无
+- 其他说明
+  - 如果存储文件不存在，创建新的并存储
+  - 如果存储文件已存在，覆盖存储
+  - 存储在用户文件夹下 `.blog-data` 目录中，文件名为 `about.md`

--- a/apps/server/admin-legacy/eslint.config.mjs
+++ b/apps/server/admin-legacy/eslint.config.mjs
@@ -1,0 +1,18 @@
+import eslintConfig from '@config/eslint';
+
+export default [
+  ...eslintConfig.recommendedTypeScript,
+  {
+    // Legacy project - relax strict any-related rules
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
+      '@typescript-eslint/no-misused-spread': 'off',
+    },
+  },
+];

--- a/apps/server/admin-legacy/package.json
+++ b/apps/server/admin-legacy/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "admin-legacy",
+  "type": "module",
+  "scripts": {
+    "build": "bun run build.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --passWithNoTests --forceExit"
+  },
+  "dependencies": {
+    "@koa/router": "catalog:",
+    "@library/koa-middlewares": "workspace:^",
+    "@module/classes": "workspace:^",
+    "axios": "^1.8.4",
+    "ioredis": "^5.6.1",
+    "koa": "catalog:",
+    "koa-body": "^6.0.1",
+    "koa-compose": "catalog:",
+    "koa-session": "^7.0.2",
+    "signale": "^1.4.0"
+  },
+  "devDependencies": {
+    "@config/bun": "workspace:^",
+    "@config/eslint": "workspace:^",
+    "@config/typescript": "workspace:^",
+    "@types/jest": "^29.5.14",
+    "@types/koa": "catalog:",
+    "@types/koa-compose": "catalog:",
+    "@types/koa__router": "^12.0.4",
+    "@types/node": "catalog:",
+    "@types/signale": "^1.4.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.2",
+    "typescript": "catalog:"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    }
+  },
+  "signale": {
+    "displayDate": true,
+    "displayTimestamp": true
+  }
+}

--- a/apps/server/admin-legacy/src/CONFIG/BODY.ts
+++ b/apps/server/admin-legacy/src/CONFIG/BODY.ts
@@ -1,0 +1,12 @@
+import {FailServerResponse} from '@module/classes';
+import {type koaBody} from 'koa-body';
+import signale from 'signale';
+
+export const BODY: Parameters<typeof koaBody>[0] = {
+  multipart: true,
+  jsonLimit: 10 * 1024 * 1024,
+  onError: (err, ctx) => {
+    signale.error(err);
+    ctx.response.body = new FailServerResponse('请求参数错误');
+  },
+};

--- a/apps/server/admin-legacy/src/CONFIG/DATABASE.ts
+++ b/apps/server/admin-legacy/src/CONFIG/DATABASE.ts
@@ -1,0 +1,5 @@
+export const DATABASE = {
+  ADDRESS: 'http://database-server:4000', // 注意不要有最后的斜杠
+  USERNAME: 'Soulike',
+  PASSWORD: 'Soulike@Database',
+};

--- a/apps/server/admin-legacy/src/CONFIG/SERVER.ts
+++ b/apps/server/admin-legacy/src/CONFIG/SERVER.ts
@@ -1,0 +1,4 @@
+export const SERVER = {
+  PORT: 4003,
+  STATIC_POSITION: '/.blog-data',
+};

--- a/apps/server/admin-legacy/src/CONFIG/SESSION.ts
+++ b/apps/server/admin-legacy/src/CONFIG/SESSION.ts
@@ -1,0 +1,28 @@
+import {SessionOptions} from 'koa-session';
+
+import {ioredis} from '../Singleton/index.js';
+
+export const SESSION: Partial<SessionOptions> = {
+  key: 'sess' /** (string) cookie key (default is koa:sess) */,
+  /** (number || 'session') maxAge in ms (default is 1 day) */
+  /** 'session' will result in a cookie that expires when session/browser is closed */
+  /** Warning: If a session cookie is stolen, this cookie will never expire */
+  signed: false,
+  /** (boolean) signed or not (default true) */
+  store: {
+    get: async (key) => {
+      const value = await ioredis.get(key);
+      if (value !== null) {
+        return JSON.parse(value);
+      } else {
+        return value;
+      }
+    },
+    set: async (key, sess, maxAge) => {
+      await ioredis.set(key, JSON.stringify(sess), 'PX', maxAge);
+    },
+    destroy: async (key) => {
+      await ioredis.del(key);
+    },
+  },
+};

--- a/apps/server/admin-legacy/src/CONFIG/index.ts
+++ b/apps/server/admin-legacy/src/CONFIG/index.ts
@@ -1,0 +1,4 @@
+export * from './BODY.js';
+export * from './DATABASE.js';
+export * from './SERVER.js';
+export * from './SESSION.js';

--- a/apps/server/admin-legacy/src/Database/Article/ROUTE.ts
+++ b/apps/server/admin-legacy/src/Database/Article/ROUTE.ts
@@ -1,0 +1,15 @@
+import {DATABASE} from '../../CONFIG/index.js';
+
+function prefix(url: string): string {
+  return `${DATABASE.ADDRESS}/article${url}`;
+}
+
+export const ADD = prefix('/add');
+export const DELETE_BY_ID = prefix('/deleteById');
+export const MODIFY = prefix('/modify');
+export const GET = prefix('/get');
+export const GET_ALL = prefix('/getAll');
+export const GET_BY_DATE = prefix('/getByDate');
+export const COUNT = prefix('/count');
+export const COUNT_ALL = prefix('/countAll');
+export const ADD_PAGE_VIEW = prefix('/addPageView');

--- a/apps/server/admin-legacy/src/Database/Article/Request.ts
+++ b/apps/server/admin-legacy/src/Database/Article/Request.ts
@@ -1,0 +1,96 @@
+import {type Article, type ServerResponse} from '@module/classes';
+
+import {axiosInstance} from '../CONFIG.js';
+import {
+  ADD,
+  ADD_PAGE_VIEW,
+  COUNT,
+  COUNT_ALL,
+  DELETE_BY_ID,
+  GET,
+  GET_ALL,
+  GET_BY_DATE,
+  MODIFY,
+} from './ROUTE.js';
+
+export async function add(
+  article: Pick<Article, 'title' | 'content' | 'category' | 'isVisible'>,
+): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(ADD, article);
+  return data;
+}
+
+export async function deleteById(id: number): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(DELETE_BY_ID, {
+    id,
+  });
+  return data;
+}
+
+export async function modify(
+  article: Pick<Article, 'id'> &
+    Partial<
+      Omit<Article, 'publicationTime' | 'modificationTime' | 'pageViews'>
+    >,
+): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(
+    MODIFY,
+    article,
+  );
+  return data;
+}
+
+export async function get(
+  article: Partial<Article>,
+): Promise<ServerResponse<Article[]>> {
+  const {data} = await axiosInstance.get<ServerResponse<Article[]>>(GET, {
+    params: {
+      json: JSON.stringify(article),
+    },
+  });
+  return data;
+}
+
+export async function getAll(): Promise<ServerResponse<Article[]>> {
+  const {data} = await axiosInstance.get<ServerResponse<Article[]>>(GET_ALL);
+  return data;
+}
+
+export async function getByDate(
+  year: number,
+  month?: number,
+  day?: number,
+): Promise<ServerResponse<Article[]>> {
+  const {data} = await axiosInstance.get<ServerResponse<Article[]>>(
+    GET_BY_DATE,
+    {
+      params: {
+        json: JSON.stringify({year, month, day}),
+      },
+    },
+  );
+  return data;
+}
+
+export async function count(
+  article: Partial<Article>,
+): Promise<ServerResponse<number>> {
+  const {data} = await axiosInstance.get<ServerResponse<number>>(COUNT, {
+    params: {
+      json: JSON.stringify(article),
+    },
+  });
+  return data;
+}
+
+export async function countAll(): Promise<ServerResponse<number>> {
+  const {data} = await axiosInstance.get<ServerResponse<number>>(COUNT_ALL);
+  return data;
+}
+
+export async function addPageView(id: number): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(ADD_PAGE_VIEW, {
+    id,
+  });
+  return data;
+}

--- a/apps/server/admin-legacy/src/Database/Article/index.ts
+++ b/apps/server/admin-legacy/src/Database/Article/index.ts
@@ -1,0 +1,1 @@
+export * from './Request.js';

--- a/apps/server/admin-legacy/src/Database/CONFIG.ts
+++ b/apps/server/admin-legacy/src/Database/CONFIG.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+import {DATABASE} from '../CONFIG/index.js';
+
+export const axiosInstance = axios.create({
+  responseType: 'json',
+  auth: {
+    username: DATABASE.USERNAME,
+    password: DATABASE.PASSWORD,
+  },
+});

--- a/apps/server/admin-legacy/src/Database/Category/ROUTE.ts
+++ b/apps/server/admin-legacy/src/Database/Category/ROUTE.ts
@@ -1,0 +1,12 @@
+import {DATABASE} from '../../CONFIG/index.js';
+
+function prefix(url: string): string {
+  return `${DATABASE.ADDRESS}/category${url}`;
+}
+
+export const GET = prefix('/get');
+export const GET_ALL = prefix('/getAll');
+export const ADD = prefix('/add');
+export const DELETE_BY_ID = prefix('/deleteById');
+export const MODIFY = prefix('/modify');
+export const COUNT_ARTICLE_BY_ID = prefix('/countArticleById');

--- a/apps/server/admin-legacy/src/Database/Category/Request.ts
+++ b/apps/server/admin-legacy/src/Database/Category/Request.ts
@@ -1,0 +1,65 @@
+import {type Category, type ServerResponse} from '@module/classes';
+
+import {axiosInstance} from '../CONFIG.js';
+import {
+  ADD,
+  COUNT_ARTICLE_BY_ID,
+  DELETE_BY_ID,
+  GET,
+  GET_ALL,
+  MODIFY,
+} from './ROUTE.js';
+
+export async function get(
+  category: Partial<Category>,
+): Promise<ServerResponse<Category[]>> {
+  const {data} = await axiosInstance.get<ServerResponse<Category[]>>(GET, {
+    params: {
+      json: JSON.stringify(category),
+    },
+  });
+  return data;
+}
+
+export async function getAll(): Promise<ServerResponse<Category[]>> {
+  const {data} = await axiosInstance.get<ServerResponse<Category[]>>(GET_ALL);
+  return data;
+}
+
+export async function add(
+  category: Omit<Category, 'id'>,
+): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(ADD, category);
+  return data;
+}
+
+export async function deleteById(id: number): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(DELETE_BY_ID, {
+    id,
+  });
+  return data;
+}
+
+export async function modify(
+  category: Partial<Category> & Pick<Category, 'id'>,
+): Promise<ServerResponse<void>> {
+  const {data} = await axiosInstance.post<ServerResponse<void>>(
+    MODIFY,
+    category,
+  );
+  return data;
+}
+
+export async function countArticleById(
+  id: number,
+): Promise<ServerResponse<number>> {
+  const {data} = await axiosInstance.get<ServerResponse<number>>(
+    COUNT_ARTICLE_BY_ID,
+    {
+      params: {
+        json: JSON.stringify({id}),
+      },
+    },
+  );
+  return data;
+}

--- a/apps/server/admin-legacy/src/Database/Category/index.ts
+++ b/apps/server/admin-legacy/src/Database/Category/index.ts
@@ -1,0 +1,1 @@
+export * from './Request.js';

--- a/apps/server/admin-legacy/src/Database/index.ts
+++ b/apps/server/admin-legacy/src/Database/index.ts
@@ -1,0 +1,4 @@
+import * as Article from './Article/index.js';
+import * as Category from './Category/index.js';
+
+export {Article, Category};

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Article/Dispatcher.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Article/Dispatcher.ts
@@ -1,0 +1,93 @@
+import {jsonQsParser} from '@library/koa-middlewares';
+import {Article, FailServerResponse} from '@module/classes';
+
+import {Article as ArticleService} from '../../../Service/index.js';
+import {AppRouter} from '../../../types.js';
+import {onJSONQsParseError} from '../../Function.js';
+import {
+  ADD,
+  DELETE_BY_ID,
+  GET_ALL,
+  GET_BY_CATEGORY,
+  GET_BY_ID,
+  MODIFY,
+} from './ROUTE.js';
+
+export default (router: AppRouter) => {
+  router.get(
+    GET_BY_ID,
+    jsonQsParser({onError: onJSONQsParseError}),
+    async (ctx, next) => {
+      try {
+        const {id} = ctx.request.body;
+        if (typeof id !== 'number') {
+          ctx.response.body = new FailServerResponse('请求参数错误');
+        } else {
+          ctx.response.body = await ArticleService.getById(id);
+        }
+      } finally {
+        await next();
+      }
+    },
+  );
+
+  router.get(GET_ALL, async (ctx, next) => {
+    try {
+      ctx.response.body = await ArticleService.getAll();
+    } finally {
+      await next();
+    }
+  });
+
+  router.get(
+    GET_BY_CATEGORY,
+    jsonQsParser({onError: onJSONQsParseError}),
+    async (ctx, next) => {
+      try {
+        const {category} = ctx.request.body;
+        if (typeof category !== 'number') {
+          ctx.response.body = new FailServerResponse('请求参数错误');
+        } else {
+          ctx.response.body = await ArticleService.getByCategory(category);
+        }
+      } finally {
+        await next();
+      }
+    },
+  );
+
+  router.post(ADD, async (ctx, next) => {
+    try {
+      // 参数检查在数据库层
+      ctx.response.body = await ArticleService.add(
+        Article.from(ctx.request.body),
+      );
+    } finally {
+      await next();
+    }
+  });
+
+  router.post(DELETE_BY_ID, async (ctx, next) => {
+    try {
+      const {id} = ctx.request.body;
+      if (typeof id !== 'number') {
+        ctx.response.body = new FailServerResponse('请求参数错误');
+      } else {
+        ctx.response.body = await ArticleService.deleteById(id);
+      }
+    } finally {
+      await next();
+    }
+  });
+
+  router.post(MODIFY, async (ctx, next) => {
+    try {
+      // 参数检查在数据库层
+      ctx.response.body = await ArticleService.modify(
+        Article.from(ctx.request.body),
+      );
+    } finally {
+      await next();
+    }
+  });
+};

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Article/ROUTE.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Article/ROUTE.ts
@@ -1,0 +1,12 @@
+import {prefix as blogPrefix} from '../Function.js';
+
+function prefix(url: string): string {
+  return blogPrefix(`/article${url}`);
+}
+
+export const GET_BY_ID = prefix('/getById');
+export const GET_ALL = prefix('/getAll');
+export const GET_BY_CATEGORY = prefix('/getByCategory');
+export const ADD = prefix('/add');
+export const DELETE_BY_ID = prefix('/deleteById');
+export const MODIFY = prefix('/modify');

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Article/index.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Article/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Dispatcher.js';

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Category/Dispatcher.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Category/Dispatcher.ts
@@ -1,0 +1,102 @@
+import {jsonQsParser} from '@library/koa-middlewares';
+import {Category, FailServerResponse} from '@module/classes';
+
+import {Category as CategoryService} from '../../../Service/index.js';
+import {AppRouter} from '../../../types.js';
+import {onJSONQsParseError} from '../../Function.js';
+import {
+  ADD,
+  DELETE_BY_ID,
+  GET_ALL,
+  GET_ALL_ARTICLE_AMOUNT_BY_ID,
+  GET_ARTICLE_AMOUNT_BY_ID,
+  GET_BY_ID,
+  MODIFY,
+} from './ROUTE.js';
+
+export default (router: AppRouter) => {
+  router.get(
+    GET_BY_ID,
+    jsonQsParser({onError: onJSONQsParseError}),
+    async (ctx, next) => {
+      try {
+        const {id} = ctx.request.body;
+        if (typeof id !== 'number') {
+          ctx.response.body = new FailServerResponse('请求参数错误');
+        } else {
+          ctx.response.body = await CategoryService.getById(id);
+        }
+      } finally {
+        await next();
+      }
+    },
+  );
+
+  router.get(GET_ALL, async (ctx, next) => {
+    try {
+      ctx.response.body = await CategoryService.getAll();
+    } finally {
+      await next();
+    }
+  });
+
+  router.get(GET_ALL_ARTICLE_AMOUNT_BY_ID, async (ctx, next) => {
+    try {
+      ctx.response.body = await CategoryService.getAllArticleAmountById();
+    } finally {
+      await next();
+    }
+  });
+
+  router.get(
+    GET_ARTICLE_AMOUNT_BY_ID,
+    jsonQsParser({onError: onJSONQsParseError}),
+    async (ctx, next) => {
+      try {
+        const {id} = ctx.request.body;
+        if (typeof id !== 'number') {
+          ctx.response.body = new FailServerResponse('请求参数错误');
+        } else {
+          ctx.response.body = await CategoryService.getArticleAmountById(id);
+        }
+      } finally {
+        await next();
+      }
+    },
+  );
+
+  router.post(ADD, async (ctx, next) => {
+    try {
+      // 参数检查在数据库层
+      ctx.response.body = await CategoryService.add(
+        Category.from(ctx.request.body),
+      );
+    } finally {
+      await next();
+    }
+  });
+
+  router.post(DELETE_BY_ID, async (ctx, next) => {
+    try {
+      const {id} = ctx.request.body;
+      if (typeof id !== 'number') {
+        ctx.response.body = new FailServerResponse('请求参数错误');
+      } else {
+        ctx.response.body = await CategoryService.deleteById(id);
+      }
+    } finally {
+      await next();
+    }
+  });
+
+  router.post(MODIFY, async (ctx, next) => {
+    try {
+      // 参数检查在数据库层
+      ctx.response.body = await CategoryService.modify(
+        Category.from(ctx.request.body),
+      );
+    } finally {
+      await next();
+    }
+  });
+};

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Category/ROUTE.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Category/ROUTE.ts
@@ -1,0 +1,13 @@
+import {prefix as blogPrefix} from '../Function.js';
+
+function prefix(url: string): string {
+  return blogPrefix(`/category${url}`);
+}
+
+export const GET_BY_ID = prefix('/getById');
+export const GET_ALL = prefix('/getAll');
+export const GET_ALL_ARTICLE_AMOUNT_BY_ID = prefix('/getAllArticleAmountById');
+export const GET_ARTICLE_AMOUNT_BY_ID = prefix('/getArticleAmountById');
+export const ADD = prefix('/add');
+export const DELETE_BY_ID = prefix('/deleteById');
+export const MODIFY = prefix('/modify');

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Category/index.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Category/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Dispatcher.js';

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Dispatcher.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Dispatcher.ts
@@ -1,0 +1,10 @@
+import {AppRouter} from '../../types.js';
+import articleDispatcher from './Article/index.js';
+import categoryDispatcher from './Category/index.js';
+import optionDispatcher from './Option/index.js';
+
+export default (router: AppRouter) => {
+  articleDispatcher(router);
+  categoryDispatcher(router);
+  optionDispatcher(router);
+};

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Function.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Function.ts
@@ -1,0 +1,3 @@
+export function prefix(url: string): string {
+  return `/blog${url}`;
+}

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Option/Dispatcher.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Option/Dispatcher.ts
@@ -1,0 +1,28 @@
+import {FailServerResponse} from '@module/classes';
+
+import {Option} from '../../../Service/index.js';
+import {AppRouter} from '../../../types.js';
+import {GET_ABOUT, SET_ABOUT} from './ROUTE.js';
+
+export default (router: AppRouter) => {
+  router.get(GET_ABOUT, async (ctx, next) => {
+    try {
+      ctx.response.body = await Option.get();
+    } finally {
+      await next();
+    }
+  });
+
+  router.post(SET_ABOUT, async (ctx, next) => {
+    try {
+      const {about} = ctx.request.body;
+      if (typeof about !== 'string') {
+        ctx.response.body = new FailServerResponse('请求参数错误');
+      } else {
+        ctx.response.body = await Option.set(about);
+      }
+    } finally {
+      await next();
+    }
+  });
+};

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Option/ROUTE.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Option/ROUTE.ts
@@ -1,0 +1,8 @@
+import {prefix as blogPrefix} from '../Function.js';
+
+function prefix(url: string): string {
+  return blogPrefix(`/option${url}`);
+}
+
+export const GET_ABOUT = prefix('/getAbout');
+export const SET_ABOUT = prefix('/setAbout');

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/Option/index.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/Option/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Dispatcher.js';

--- a/apps/server/admin-legacy/src/Dispatcher/Blog/index.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Blog/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Dispatcher.js';

--- a/apps/server/admin-legacy/src/Dispatcher/Function.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Function.ts
@@ -1,0 +1,7 @@
+import {FailServerResponse} from '@module/classes';
+import {type Context} from 'koa';
+
+export function onJSONQsParseError(e: unknown, ctx: Context): void {
+  ctx.response.status = 400;
+  ctx.response.body = new FailServerResponse('请求参数错误');
+}

--- a/apps/server/admin-legacy/src/Dispatcher/Router.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/Router.ts
@@ -1,0 +1,10 @@
+import Router from '@koa/router';
+
+import blogDispatcher from './Blog/index.js';
+
+const router = new Router();
+
+// 在此注入 router 到各个 dispatcher
+blogDispatcher(router);
+
+export default router;

--- a/apps/server/admin-legacy/src/Dispatcher/index.ts
+++ b/apps/server/admin-legacy/src/Dispatcher/index.ts
@@ -1,0 +1,13 @@
+import {errorHandling} from '@library/koa-middlewares';
+import compose from 'koa-compose';
+import signale from 'signale';
+
+import router from './Router.js';
+
+export default () => {
+  return compose([
+    errorHandling(signale.error),
+    router.routes(),
+    router.allowedMethods(),
+  ]);
+};

--- a/apps/server/admin-legacy/src/Middleware/SessionChecker.ts
+++ b/apps/server/admin-legacy/src/Middleware/SessionChecker.ts
@@ -1,0 +1,12 @@
+import {FailServerResponse} from '@module/classes';
+import {type Middleware} from 'koa';
+
+export default (): Middleware => {
+  return async (ctx, next) => {
+    if (ctx.session === null || typeof ctx.session.username !== 'string') {
+      ctx.response.body = new FailServerResponse('请先登录');
+    } else {
+      await next();
+    }
+  };
+};

--- a/apps/server/admin-legacy/src/Middleware/index.ts
+++ b/apps/server/admin-legacy/src/Middleware/index.ts
@@ -1,0 +1,1 @@
+export {default as sessionChecker} from './SessionChecker.js';

--- a/apps/server/admin-legacy/src/Service/Article.ts
+++ b/apps/server/admin-legacy/src/Service/Article.ts
@@ -1,0 +1,52 @@
+import {
+  type Article,
+  FailServerResponse,
+  type ServerResponse,
+  SuccessfulServerResponse,
+} from '@module/classes';
+
+import {Article as ArticleTable} from '../Database/index.js';
+
+export async function getById(id: number): Promise<ServerResponse<Article>> {
+  const serverResponse = await ArticleTable.get({id});
+  if (serverResponse.isSuccessful) {
+    const {data} = serverResponse;
+    if (typeof data !== 'undefined' && data.length !== 0) {
+      return new SuccessfulServerResponse(data[0]);
+    } else {
+      return new FailServerResponse('文章不存在');
+    }
+  } else {
+    const {message} = serverResponse;
+    return new FailServerResponse(message);
+  }
+}
+
+export async function getAll(): Promise<ServerResponse<Article[]>> {
+  return await ArticleTable.getAll();
+}
+
+export async function getByCategory(
+  category: number,
+): Promise<ServerResponse<Article[]>> {
+  return await ArticleTable.get({category});
+}
+
+export async function add(
+  article: Pick<Article, 'title' | 'content' | 'category' | 'isVisible'>,
+): Promise<ServerResponse<void>> {
+  return await ArticleTable.add(article);
+}
+
+export async function deleteById(id: number): Promise<ServerResponse<void>> {
+  return await ArticleTable.deleteById(id);
+}
+
+export async function modify(
+  article: Pick<Article, 'id'> &
+    Partial<
+      Omit<Article, 'publicationTime' | 'modificationTime' | 'pageViews'>
+    >,
+): Promise<ServerResponse<void>> {
+  return await ArticleTable.modify(article);
+}

--- a/apps/server/admin-legacy/src/Service/Category.ts
+++ b/apps/server/admin-legacy/src/Service/Category.ts
@@ -1,0 +1,85 @@
+import {
+  type Category,
+  FailServerResponse,
+  type ServerResponse,
+  SuccessfulServerResponse,
+} from '@module/classes';
+
+import {Category as CategoryTable} from '../Database/index.js';
+
+export async function getById(id: number): Promise<ServerResponse<Category>> {
+  const serverResponse = await CategoryTable.get({id});
+  if (serverResponse.isSuccessful) {
+    const {data: categories} = serverResponse;
+    if (categories.length === 0) {
+      return new FailServerResponse('文章分类不存在');
+    } else {
+      return new SuccessfulServerResponse(categories[0]);
+    }
+  } else {
+    const {message} = serverResponse;
+    return new FailServerResponse(message);
+  }
+}
+
+export async function getAll(): Promise<ServerResponse<Category[]>> {
+  return await CategoryTable.getAll();
+}
+
+export async function getAllArticleAmountById(): Promise<
+  ServerResponse<Record<number, number>>
+> {
+  const categoryTableServerResponse = await CategoryTable.getAll();
+  if (categoryTableServerResponse.isSuccessful) {
+    const {data: categories} = categoryTableServerResponse;
+    const idToResponse: Record<string, ServerResponse<number>> = {};
+    await Promise.all(
+      categories.map(async (category) => {
+        idToResponse[category.id] = await CategoryTable.countArticleById(
+          category.id,
+        );
+      }),
+    );
+
+    const ids = Object.keys(idToResponse);
+    const idToArticleAmount: Record<string, number> = {};
+
+    for (const id of ids) {
+      const categoryIdServerResponse = idToResponse[id];
+      if (categoryIdServerResponse.isSuccessful) {
+        const {data} = categoryIdServerResponse;
+        idToArticleAmount[id] = data;
+      } else {
+        const {message} = categoryIdServerResponse;
+        return new FailServerResponse(message);
+      }
+    }
+
+    return new SuccessfulServerResponse(idToArticleAmount);
+  } else {
+    const {message} = categoryTableServerResponse;
+    return new FailServerResponse(message);
+  }
+}
+
+export async function getArticleAmountById(
+  id: number,
+): Promise<ServerResponse<number>> {
+  return await CategoryTable.countArticleById(id);
+}
+
+export async function add(
+  category: Omit<Category, 'id'>,
+): Promise<ServerResponse<void>> {
+  return await CategoryTable.add(category);
+}
+
+export async function deleteById(id: number): Promise<ServerResponse<void>> {
+  return await CategoryTable.deleteById(id);
+}
+
+export async function modify(
+  category: Partial<Category> & Pick<Category, 'id'>,
+): Promise<ServerResponse<void>> {
+  return await CategoryTable.modify(category);
+}

--- a/apps/server/admin-legacy/src/Service/Option.ts
+++ b/apps/server/admin-legacy/src/Service/Option.ts
@@ -1,0 +1,21 @@
+import {type ServerResponse, SuccessfulServerResponse} from '@module/classes';
+import {promises as fs} from 'fs';
+import path from 'path';
+
+import {SERVER} from '../CONFIG/index.js';
+
+export async function get(): Promise<ServerResponse<{about: string}>> {
+  const content = await fs.readFile(
+    path.join(SERVER.STATIC_POSITION, 'about.md'),
+    {encoding: 'utf-8'},
+  );
+  return new SuccessfulServerResponse({about: content});
+}
+
+export async function set(about: string): Promise<ServerResponse<void>> {
+  await fs.mkdir(SERVER.STATIC_POSITION, {recursive: true});
+  await fs.writeFile(path.join(SERVER.STATIC_POSITION, 'about.md'), about, {
+    encoding: 'utf-8',
+  });
+  return new SuccessfulServerResponse(undefined);
+}

--- a/apps/server/admin-legacy/src/Service/index.ts
+++ b/apps/server/admin-legacy/src/Service/index.ts
@@ -1,0 +1,5 @@
+import * as Article from './Article.js';
+import * as Category from './Category.js';
+import * as Option from './Option.js';
+
+export {Article, Category, Option};

--- a/apps/server/admin-legacy/src/Singleton/index.ts
+++ b/apps/server/admin-legacy/src/Singleton/index.ts
@@ -1,0 +1,1 @@
+export * from './ioredis.js';

--- a/apps/server/admin-legacy/src/Singleton/ioredis.ts
+++ b/apps/server/admin-legacy/src/Singleton/ioredis.ts
@@ -1,0 +1,7 @@
+// see https://github.com/luin/ioredis
+
+import {Redis} from 'ioredis';
+
+export const ioredis = new Redis({
+  host: 'redis',
+});

--- a/apps/server/admin-legacy/src/index.ts
+++ b/apps/server/admin-legacy/src/index.ts
@@ -1,0 +1,28 @@
+import {requestLogger} from '@library/koa-middlewares';
+import Koa from 'koa';
+import {koaBody} from 'koa-body';
+import session from 'koa-session';
+import signale from 'signale';
+
+import {BODY, SERVER, SESSION} from './CONFIG/index.js';
+import dispatcher from './Dispatcher/index.js';
+import {sessionChecker} from './Middleware/index.js';
+
+const app = new Koa();
+
+app.on('error', (e: unknown) => {
+  if (e instanceof Error)
+    signale.error(`未捕获的错误：\n${e.name}\n${e.message}\n${e.stack ?? ''}`);
+  else signale.error(`未捕获的错误：\n${JSON.stringify(e)}`);
+});
+
+app.use(session(SESSION, app));
+app.use(sessionChecker()); // 检查是否已经登录，未登录就直接返回
+app.use(koaBody(BODY));
+app.use(requestLogger(signale.info));
+app.use(dispatcher());
+app.listen(SERVER.PORT, () => {
+  signale.info(
+    `Server is running on port ${SERVER.PORT} (PID: ${process.pid})`,
+  );
+});

--- a/apps/server/admin-legacy/src/koa-body.d.ts
+++ b/apps/server/admin-legacy/src/koa-body.d.ts
@@ -1,0 +1,9 @@
+import type {Files} from 'formidable';
+import * as Koa from 'koa';
+
+declare module 'koa' {
+  interface Request extends Koa.BaseRequest {
+    body?: any;
+    files?: Files;
+  }
+}

--- a/apps/server/admin-legacy/src/types.ts
+++ b/apps/server/admin-legacy/src/types.ts
@@ -1,0 +1,4 @@
+import * as Router from '@koa/router';
+
+// Re-export a properly typed Router for use in dispatchers
+export type AppRouter = Router.RouterInstance;

--- a/apps/server/admin-legacy/tsconfig.json
+++ b/apps/server/admin-legacy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@config/typescript/node",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "exclude": ["build.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,35 @@
         "typescript": "catalog:",
       },
     },
+    "apps/server/admin-legacy": {
+      "name": "admin-legacy",
+      "dependencies": {
+        "@koa/router": "catalog:",
+        "@library/koa-middlewares": "workspace:^",
+        "@module/classes": "workspace:^",
+        "axios": "^1.8.4",
+        "ioredis": "^5.6.1",
+        "koa": "catalog:",
+        "koa-body": "^6.0.1",
+        "koa-compose": "catalog:",
+        "koa-session": "^7.0.2",
+        "signale": "^1.4.0",
+      },
+      "devDependencies": {
+        "@config/bun": "workspace:^",
+        "@config/eslint": "workspace:^",
+        "@config/typescript": "workspace:^",
+        "@types/jest": "^29.5.14",
+        "@types/koa": "catalog:",
+        "@types/koa-compose": "catalog:",
+        "@types/koa__router": "^12.0.4",
+        "@types/node": "catalog:",
+        "@types/signale": "^1.4.7",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "typescript": "catalog:",
+      },
+    },
     "apps/server/auth": {
       "name": "auth",
       "dependencies": {
@@ -1387,6 +1416,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "8.15.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "admin-legacy": ["admin-legacy@workspace:apps/server/admin-legacy"],
+
     "admin-vite": ["admin-vite@workspace:apps/web/admin-vite"],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -2377,7 +2408,7 @@
 
     "pkg-conf": ["pkg-conf@2.1.0", "", { "dependencies": { "find-up": "2.1.0", "load-json-file": "4.0.0" } }, "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g=="],
 
-    "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2537,7 +2568,7 @@
 
     "slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "6.2.1", "is-fullwidth-code-point": "5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
 
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -3011,8 +3042,6 @@
 
     "git-raw-commits/meow": ["meow@12.1.1", "", {}, "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="],
 
-    "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "http-assert/http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "1.5.0", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
@@ -3020,8 +3049,6 @@
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
-    "import-local/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "ioredis/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -3081,6 +3108,8 @@
 
     "miller-rabin/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
+    "node-stdlib-browser/pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "pbkdf2/create-hash": ["create-hash@1.1.3", "", { "dependencies": { "cipher-base": "1.0.6", "inherits": "2.0.4", "ripemd160": "2.0.1", "sha.js": "2.4.12" } }, "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA=="],
@@ -3088,6 +3117,8 @@
     "pbkdf2/ripemd160": ["ripemd160@2.0.1", "", { "dependencies": { "hash-base": "2.0.2", "inherits": "2.0.4" } }, "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w=="],
 
     "pkg-conf/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
+
+    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -3107,6 +3138,8 @@
 
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "rollup-plugin-visualizer/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "3.2.1", "escape-string-regexp": "1.0.5", "supports-color": "5.5.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
@@ -3114,8 +3147,6 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "1.3.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
-
-    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -3205,8 +3236,6 @@
 
     "@jest/reporters/istanbul-lib-source-maps/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@jest/reporters/istanbul-lib-source-maps/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "@library/html-sanitizer/jsdom/cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "@library/html-sanitizer/jsdom/data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
@@ -3277,8 +3306,6 @@
 
     "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
-    "import-local/pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
     "jest-circus/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "jest-circus/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -3322,6 +3349,8 @@
     "pbkdf2/ripemd160/hash-base": ["hash-base@2.0.2", "", { "dependencies": { "inherits": "2.0.4" } }, "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw=="],
 
     "pkg-conf/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "2.0.0", "path-exists": "3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
+
+    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "react-transition-group/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
@@ -3369,11 +3398,11 @@
 
     "co-body/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "import-local/pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
     "pkg-conf/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "1.3.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "pkg-conf/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "signale/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
@@ -3391,9 +3420,9 @@
 
     "@library/html-sanitizer/jsdom/whatwg-url/tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "import-local/pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
     "pkg-conf/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
+
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "signale/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
@@ -3401,8 +3430,6 @@
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
-    "import-local/pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "import-local/pkg-dir/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+    "pkg-dir/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
   }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,7 +40,7 @@ services:
       - database
   admin-server:
     restart: always
-    image: 'soulike/admin-server:latest'
+    image: 'soulike/admin-server-legacy:latest'
     volumes:
       - $HOME/.blog-data:/.blog-data
     depends_on:


### PR DESCRIPTION
## Summary
- Migrate admin server from external servers monorepo into this bun monorepo as `admin-legacy`
- Follow the same migration pattern used for `auth-legacy` and `database-legacy`
- Update `compose.yaml` to use the new `admin-server-legacy` image

## Changes
- Add `apps/server/admin-legacy/` with migrated source code
- Update imports to use workspace packages (`@module/classes`, `@library/koa-middlewares`)
- Add ESM support with `.js` extensions on relative imports
- Add build configuration files (`build.ts`, `tsconfig.json`, `eslint.config.mjs`)
- Add `Dockerfile` for container builds (port 4003)
- Add GitHub Actions workflow for CI/CD

## Test plan
- [x] `bun install` succeeds
- [x] `bun run typecheck` passes in admin-legacy
- [x] `bun run build` succeeds in admin-legacy
- [x] Docker image builds successfully
- [x] Server starts and responds to requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)