### PR TITLE
refactor(nginx): switch to Docker-native log rotation

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -85,7 +85,11 @@ services:
       - admin-server
     volumes:
       - $HOME/ssl:/ssl:ro
-      - ./nginx/logs:/var/log/nginx
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     ports:
       - 80:80
       - 443:443

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -5,4 +5,8 @@ The folder contains configuration and build files for NGINX docker image.
 ## Volumes
 
 1. **/ssl**: Should contain SSL certificates.
-2. **/var/log/nginx**: Logs.
+
+## Logging
+
+Logs are sent to stdout/stderr and managed by Docker's logging driver. Configure
+log rotation via the `logging` option in `compose.yaml`.

--- a/nginx/configurations/conf.d/admin.conf
+++ b/nginx/configurations/conf.d/admin.conf
@@ -2,7 +2,7 @@ server {
   server_name admin.soulike.tech;
 
   charset utf-8;
-  access_log /var/log/nginx/admin.log main;
+  access_log /dev/stdout main;
 
   location / {
     include /etc/nginx/proxy.conf;

--- a/nginx/configurations/conf.d/blog.conf
+++ b/nginx/configurations/conf.d/blog.conf
@@ -2,7 +2,7 @@ server {
   server_name soulike.tech;
 
   charset utf-8;
-  access_log /var/log/nginx/blog.log main;
+  access_log /dev/stdout main;
 
   location / {
     include /etc/nginx/proxy.conf;

--- a/nginx/configurations/conf.d/default.conf
+++ b/nginx/configurations/conf.d/default.conf
@@ -1,7 +1,7 @@
 # Forbid direct IP access
 server {
   server_name 140.82.23.140 2001:19f0:6001:2785:5400:1ff:fe72:8f10 charset utf-8;
-  access_log /var/log/nginx/ip.log main;
+  access_log /dev/stdout main;
 
   listen 80 default;
   listen [::]:80 default;

--- a/nginx/configurations/conf.d/game-2048.conf
+++ b/nginx/configurations/conf.d/game-2048.conf
@@ -2,7 +2,7 @@ server {
   server_name 2048.soulike.tech;
 
   charset utf-8;
-  access_log /var/log/nginx/game-2048.log main;
+  access_log /dev/stdout main;
 
   location / {
     include /etc/nginx/proxy.conf;

--- a/nginx/configurations/nginx.conf
+++ b/nginx/configurations/nginx.conf
@@ -1,6 +1,6 @@
 worker_processes auto;
 
-error_log /var/log/nginx/error.log warn;
+error_log /dev/stderr warn;
 pid /var/run/nginx.pid;
 
 events {
@@ -11,8 +11,8 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
   log_format main
-    '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-  access_log /var/log/nginx/access.log main;
+    '[$server_name] $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+  access_log /dev/stdout main;
 
   sendfile on;
   tcp_nopush on;


### PR DESCRIPTION
## Summary

- Redirect all nginx logs to stdout/stderr instead of writing to files on disk, enabling Docker's built-in log rotation.
- Add `$server_name` to the log format so per-service log lines can still be distinguished.
- Configure `json-file` logging driver with `max-size: 10m` and `max-file: 5` for the nginx service in `compose.yaml`.
- Remove the `./nginx/logs:/var/log/nginx` volume mount since logs are no longer written to files.

## Test plan

- [ ] Deploy and verify nginx starts without errors
- [ ] Confirm `docker logs <nginx-container>` shows access/error logs with `[$server_name]` prefix
- [ ] Verify log files are rotated by Docker (check `/var/lib/docker/containers/` on the host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)