### PR TITLE
fix(server): enable proxy trust for secure cookies behind nginx

### DIFF
--- a/apps/server/admin-legacy/src/index.ts
+++ b/apps/server/admin-legacy/src/index.ts
@@ -11,6 +11,7 @@ import dispatcher from './Dispatcher/index.js';
 import {sessionChecker} from './Middleware/index.js';
 
 const app = new Koa();
+app.proxy = true;
 
 app.on('error', (e: unknown) => {
   if (e instanceof Error)

--- a/apps/server/auth-legacy/src/index.ts
+++ b/apps/server/auth-legacy/src/index.ts
@@ -10,6 +10,7 @@ import {BODY, SERVER, SESSION} from './CONFIG/index.js';
 import dispatcher from './Dispatcher/index.js';
 
 const app = new Koa();
+app.proxy = true;
 
 app.on('error', (e: unknown) => {
   if (e instanceof Error)

--- a/apps/server/auth/src/index.ts
+++ b/apps/server/auth/src/index.ts
@@ -11,6 +11,7 @@ import {LISTEN_OPTIONS} from '@/configurations/listen-options.js';
 import {dispatcher} from '@/dispatcher/index.js';
 
 const app = new Koa();
+app.proxy = true;
 
 app.on('error', (e: unknown) => {
   if (e instanceof Error) {


### PR DESCRIPTION
## Summary

- Set `app.proxy = true` on auth, auth-legacy, and admin-legacy so koa trusts `X-Forwarded-Proto` from nginx
- Fixes `Error: Cannot send secure cookie over unencrypted connection` caused by `secure: true` session cookies behind nginx reverse proxy

## Test plan

- [ ] Verify login/logout works correctly on auth and admin
- [ ] Verify session cookies are set with `Secure` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)