### PR TITLE
fix(compose): add db-password secret to auth-server

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,8 +32,10 @@ services:
     image: 'soulike/auth-server:latest'
     secrets:
       - redis-password
+      - db-password
     environment:
       - REDIS_PASSWORD_FILE=/run/secrets/redis-password
+      - DB_PASSWORD_FILE=/run/secrets/db-password
     depends_on:
       - redis
       - database-server


### PR DESCRIPTION
## Summary

- Add `db-password` secret and `DB_PASSWORD_FILE` env var to the `auth-server` service in `compose.yaml`
- The auth server uses `@module/database` which requires `DB_PASSWORD_FILE` to connect to PostgreSQL, causing a crash on startup without it

## Test plan

- [ ] Verify auth-server starts without `Env DB_PASSWORD_FILE is not provided` error


🤖 Generated with [Claude Code](https://claude.com/claude-code)