### PR TITLE
fix(auth): validate session shape in GET /session

### DIFF
--- a/apps/server/auth/src/dispatcher/user/router.ts
+++ b/apps/server/auth/src/dispatcher/user/router.ts
@@ -1,6 +1,6 @@
 import Router from '@koa/router';
 import {Logger} from '@library/logger';
-import {User} from '@module/classes';
+import {Session, User} from '@module/classes';
 import {StatusCodes} from 'http-status-codes';
 import {DefaultState} from 'koa';
 
@@ -12,6 +12,10 @@ import {SESSION} from './path.js';
 const router = new Router<DefaultState, Context>();
 
 router.get(SESSION, (ctx) => {
+  if (!Session.validate(ctx.session)) {
+    ctx.session = null;
+  }
+
   if (!ctx.session) {
     ctx.response.status = StatusCodes.NOT_FOUND;
   } else {


### PR DESCRIPTION
## Summary

- Validate `ctx.session` with `Session.validate()` before responding in `GET /session`
- If the session doesn't match the expected shape (e.g., `{}`), clear it to `null` before the existing response logic

koa-session always initializes `ctx.session` as `{}`, even without a session cookie. The old `!ctx.session` check was always false, so an empty `{}` was returned with `200`, causing the session SDK to throw `"Invalid Session"` when the user is not logged in.

## Test plan

- [ ] Visit admin when not logged in — should show login page without error notification


🤖 Generated with [Claude Code](https://claude.com/claude-code)