### PR TITLE
ci: skip Docker builds for unchanged apps in PR

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -28,6 +28,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -41,40 +42,48 @@ jobs:
               - 'apps/web/blog-vite/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             admin:
               - 'apps/web/admin-vite/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             game-2048:
               - 'apps/web/game-2048/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             auth-server:
               - 'apps/server/auth/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             auth-server-legacy:
               - 'apps/server/auth-legacy/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             admin-server-legacy:
               - 'apps/server/admin-legacy/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             blog-server-legacy:
               - 'apps/server/blog-legacy/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
             database-server-legacy:
               - 'apps/server/database-legacy/**'
               - 'modules/**'
               - 'libraries/**'
+              - 'configs/**'
               - 'bun.lock'
       - name: Build matrix
         id: build-matrix
@@ -107,7 +116,10 @@ jobs:
   ci-success:
     runs-on: ubuntu-latest
     if: always()
-    needs: build
+    needs:
+      - test
+      - changes
+      - build
     steps:
       - name: Check for failures
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
## Summary

- Use `dorny/paths-filter` to detect which apps have file changes in the PR
- Dynamically generate the build matrix to only include changed apps
- If no apps changed, the entire build job is skipped

This reduces CI time and avoids unnecessary DockerHub image pulls when only a subset of apps are modified.

## Test plan

- [ ] PR that only changes `apps/server/auth/` should only build `auth-server`
- [ ] PR that changes `modules/` should build all apps (except game-2048)
- [ ] PR that changes only CI/config files should skip all builds
- [ ] `ci-success` gate job should still pass when builds are skipped


🤖 Generated with [Claude Code](https://claude.com/claude-code)